### PR TITLE
Fixed date check

### DIFF
--- a/historical.js
+++ b/historical.js
@@ -263,7 +263,7 @@ module.exports = function (schema, options) {
             action = args[0];
         }
 
-        if (typeof args[1] == 'date') {
+        if (_.isDate(args[1])) {
             date = args[1];
         }
 


### PR DESCRIPTION
Previously this check always returned false, because `typeof` of date objects returns `'object'`. Therefore it always took current date as an argument.
