### PR TITLE
Added option for different type of `_id`

### DIFF
--- a/historical.js
+++ b/historical.js
@@ -15,7 +15,7 @@ module.exports = function (schema, options) {
 
         models[model.constructor.modelName] = models[model.constructor.modelName] === undefined ?
             connection.model(name, new Schema({
-                document: { type: ObjectId, index: true },
+                document: { type: options.idType || ObjectId, index: true },
                 timestamp: {type: Date, default: Date.now, index: true},
                 diff: Schema.Types.Mixed
             })) : models[model.constructor.modelName];


### PR DESCRIPTION
The type of `_id` of a document could be different than ObjectId, I think there should be a way to declare it.
