### PR TITLE
add hooks and tests for findOneAndRemove and update

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -242,4 +242,158 @@ describe('Document', function(){
             });
         });
     });
+
+    describe('#update()', function(){
+        var sub_document = new TestModel({
+            testNumber: 424,
+            testArray: ['test3', 'test4'],
+            testObject: {
+                testObjectElement: 'starting test object'
+            },
+            ignoredField: 'Ignore me'
+        });
+
+        it('An historical record should be created when a document is saved.', function(done){
+            TestModel.deleteMany({}, function(){
+                sub_document.save(function (e, obj) {
+                    assert.equal(e, null);
+                    assert.notEqual(obj, null);
+
+                    sub_document = obj;
+
+                    obj.historical(function (e, details) {
+                        assert.equal(e, null);
+                        assert.notEqual(details, null);
+
+                        var diff = _.merge(details.pop().diff, {_id: obj._id, __v: obj.__v});
+
+                        assert.strictEqual(diff.ignoredField, undefined);
+                        
+                        var withoutIgnored = obj.toObject();
+                        delete withoutIgnored['ignoredField'];
+                        
+                        assert.deepEqual(withoutIgnored, diff);
+                        assert.equal(obj.testString, 'My default value');
+                        
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('The post hook for update should call historical.js', function(done){
+
+            var update = {
+                $set: {
+                    testObject: {
+                        testObjectElement: 'new test object'
+                    },
+                    testString: 'new test string'
+                }
+            }
+
+            var query = {
+                testNumber: 424,
+            }
+
+            TestModel.where(query).update(update, function (e, obj) {
+                assert.equal(e, null);
+                assert.notEqual(obj, null);
+
+                sub_document = obj;
+                done();
+            });
+        });
+
+        it('An historical record should be created when a document is modified.', function(done){
+
+            var query = {
+                testObject: {
+                    testObjectElement: 'new test object'
+                },
+                testString: 'new test string'
+            }
+
+            var diffTest = {
+                testObject: {
+                    testObjectElement: 'new test object'
+                },
+                testString: 'new test string'
+            }
+
+            TestModel.findOne(query, function (e, obj) {
+                assert.equal(e, null);
+                assert.notEqual(obj, null);
+
+                sub_document = obj;
+
+                obj.historical(function (e, details) {
+                    assert.equal(e, null);
+                    assert.notEqual(details, null);
+
+                    assert.deepEqual(details.pop().diff, diffTest);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('#findOneAndRemove()', function(){
+        var sub_document = new TestModel({
+            testNumber: 424,
+            testArray: ['test3', 'test4'],
+            testObject: {
+                testObjectElement: 'starting test object'
+            },
+            ignoredField: 'Ignore me'
+        });
+
+        it('An historical record should be created when a document is saved.', function(done){
+            TestModel.deleteMany({}, function(){
+                sub_document.save(function (e, obj) {
+                    assert.equal(e, null);
+                    assert.notEqual(obj, null);
+
+                    sub_document = obj;
+
+                    obj.historical(function (e, details) {
+                        assert.equal(e, null);
+                        assert.notEqual(details, null);
+
+                        var diff = _.merge(details.pop().diff, {_id: obj._id, __v: obj.__v});
+
+                        assert.strictEqual(diff.ignoredField, undefined);
+                        
+                        var withoutIgnored = obj.toObject();
+                        delete withoutIgnored['ignoredField'];
+                        
+                        assert.deepEqual(withoutIgnored, diff);
+                        assert.equal(obj.testString, 'My default value');
+                        
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('An historical record should be null when a document is removed.', function(done){
+            TestModel.findOneAndRemove({_id: sub_document.id}, function(e, obj){
+
+                assert.equal(e, null);
+                assert.notEqual(obj, null);
+
+                obj.historical(function(e, details){
+                    assert.equal(e, null);
+                    assert.notEqual(obj, null);
+
+                    assert.equal(details.pop().diff, null);
+
+                    document.historicalRestore(new Date(), function(e, restored){
+                        assert.equal(restored, null);
+                        done();
+                    });
+                });
+            });
+        });
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -321,20 +321,22 @@ describe('Document', function(){
                 testString: 'new test string'
             }
 
-            TestModel.findOne(query, function (e, obj) {
-                assert.equal(e, null);
-                assert.notEqual(obj, null);
-
-                sub_document = obj;
-
-                obj.historical(function (e, details) {
+            setTimeout(function(){
+                TestModel.findOne(query, function (e, obj) {
                     assert.equal(e, null);
-                    assert.notEqual(details, null);
+                    assert.notEqual(obj, null);
 
-                    assert.deepEqual(details.pop().diff, diffTest);
-                    done();
+                    sub_document = obj;
+
+                    obj.historical(function (e, details) {
+                        assert.equal(e, null);
+                        assert.notEqual(details, null);
+
+                        assert.deepEqual(details.pop().diff, diffTest);
+                        done();
+                    });
                 });
-            });
+            }, 100);
         });
     });
 


### PR DESCRIPTION
Added the rest of the hooks and tests relevant to #6 , I believe this should actually close that issue now unless we want even more hooks. These were pretty straight forward after taking care of findOneAndUpdate.

closes #6 